### PR TITLE
Fix installation via setup.py (pipsi, pipx, …)

### DIFF
--- a/bandcamp_tagplayer/__main__.py
+++ b/bandcamp_tagplayer/__main__.py
@@ -1,31 +1,4 @@
-import argparse
-from tagplayer import Tagplayer
-
-"""
-bandcamp_tagplayer
-Config file at: ~/.config/bandcamp_tagplayer/config
-
-Options:
-  -h --help                 Show this screen.
-  -v --version              Show version.
-
-Code:
-    Gregory Parrish
-    https://github.com/greggparrish/bandcamp_tagplayer
-"""
+from .tagplayer import main
 
 if __name__ == '__main__':
-    p = argparse.ArgumentParser(description='Creates mpd playlists from Bandcamp genre tags.')
-    p.add_argument('tag', help='Music genre', nargs='?', default=False)
-    p.add_argument('-t', '--tag', help='Music genre', action='store', default=False)
-    p.add_argument('-u', '--user', help='Bandcamp username', action='store', default=False)
-    args = p.parse_args()
-
-    tag = None
-    user = None
-
-    try:
-        with Tagplayer(tag=args.tag, user=args.user) as tp:
-            tp.check_tag()
-    except Exception as e:
-        print(f'ERROR: {e}')
+    main()

--- a/bandcamp_tagplayer/mpd_queue.py
+++ b/bandcamp_tagplayer/mpd_queue.py
@@ -1,9 +1,9 @@
 from blessed import Terminal
 from time import sleep
-
-from config import Config
 from mpd import MPDClient
-from utils import Utils
+
+from .config import Config
+from .utils import Utils
 
 c = Config().conf_vars()
 

--- a/bandcamp_tagplayer/tagplayer.py
+++ b/bandcamp_tagplayer/tagplayer.py
@@ -359,12 +359,12 @@ def main():
     import argparse
     p = argparse.ArgumentParser(description='Creates mpd playlists from Bandcamp genre tags.')
     p.add_argument('tag', help='Music genre', nargs='?', default=False)
-    p.add_argument('-t', '--tag', help='Music genre', action='store', default=False)
+    p.add_argument('-t', '--tag', help='Music genre', action='store', dest='tag2', metavar='tag', default=False)
     p.add_argument('-u', '--user', help='Bandcamp username', action='store', default=False)
     args = p.parse_args()
 
     try:
-        with Tagplayer(tag=args.tag, user=args.user) as tp:
+        with Tagplayer(tag=(args.tag or args.tag2), user=args.user) as tp:
             tp.check_tag()
     except Exception as e:
         print(f'ERROR: {e}')

--- a/bandcamp_tagplayer/tagplayer.py
+++ b/bandcamp_tagplayer/tagplayer.py
@@ -358,9 +358,9 @@ def main():
     """
     import argparse
     p = argparse.ArgumentParser(description='Creates mpd playlists from Bandcamp genre tags.')
-    p.add_argument('tag', help='Music genre', nargs='?', default=False)
-    p.add_argument('-t', '--tag', help='Music genre', action='store', dest='tag2', metavar='tag', default=False)
-    p.add_argument('-u', '--user', help='Bandcamp username', action='store', default=False)
+    p.add_argument('tag', help='Music genre', nargs='?', default=None)
+    p.add_argument('-t', '--tag', help='Music genre', action='store', dest='tag2', metavar='tag', default=None)
+    p.add_argument('-u', '--user', help='Bandcamp username', action='store', metavar='user', default=None)
     args = p.parse_args()
 
     try:

--- a/bandcamp_tagplayer/tagplayer.py
+++ b/bandcamp_tagplayer/tagplayer.py
@@ -14,11 +14,11 @@ from mutagen import File
 from mutagen.id3 import ID3NoHeaderError
 from mutagen.easyid3 import EasyID3
 
-from config import Config
-import db
-from mpd_queue import MPDQueue
-from messages import Messages
-from utils import Utils
+from .config import Config
+from . import db
+from .mpd_queue import MPDQueue
+from .messages import Messages
+from .utils import Utils
 
 c = Config().conf_vars()
 BANNED_GENRES = [g.lower().strip() for g in c['banned_genres'].split(',')]
@@ -343,7 +343,19 @@ class Tagplayer:
         song.save()
 
 
-if __name__ == '__main__':
+def main():
+    """
+    bandcamp_tagplayer
+    Config file at: ~/.config/bandcamp_tagplayer/config
+
+    Options:
+      -h --help                 Show this screen.
+      -v --version              Show version.
+
+    Code:
+        Gregory Parrish
+        https://github.com/greggparrish/bandcamp_tagplayer
+    """
     import argparse
     p = argparse.ArgumentParser(description='Creates mpd playlists from Bandcamp genre tags.')
     p.add_argument('tag', help='Music genre', nargs='?', default=False)
@@ -351,11 +363,12 @@ if __name__ == '__main__':
     p.add_argument('-u', '--user', help='Bandcamp username', action='store', default=False)
     args = p.parse_args()
 
-    tag = None
-    user = None
-
     try:
         with Tagplayer(tag=args.tag, user=args.user) as tp:
             tp.check_tag()
     except Exception as e:
         print(f'ERROR: {e}')
+
+
+if __name__ == '__main__':
+    main()

--- a/bandcamp_tagplayer/utils.py
+++ b/bandcamp_tagplayer/utils.py
@@ -7,9 +7,9 @@ import webbrowser
 from blessed import Terminal
 from mutagen.easyid3 import EasyID3
 
-from config import Config
-import db
-from messages import Messages
+from .config import Config
+from . import db
+from .messages import Messages
 
 cf = Config().conf_vars()
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=required,
     entry_points={
         'console_scripts': [
-            'bandcamp-tagplayer=bandcamp_tagplayer.bandcamp_tagplayer:main',
+            'bandcamp-tagplayer=bandcamp_tagplayer.__main__:main',
         ],
     },
 )


### PR DESCRIPTION
* deduplicate `__main__`
* drop useless `{tag,user} = None`
* use relative imports so that it can be invoked outside of its subdir
* fix console_scripts in setup.py to actually work

Now it can be installed via `pipsi install --python python3 -e .` and
perhaps even submitted to PyPI.