### PR TITLE
MPD password support

### DIFF
--- a/bandcamp_tagplayer/config.py
+++ b/bandcamp_tagplayer/config.py
@@ -25,6 +25,7 @@ class Config:
             'cache_dir': self.format_path(conf['storage']['cache']),
             'mpd_host': conf['mpd']['host'],
             'mpd_port': conf['mpd']['port'],
+            'mpd_password': conf['mpd']['password'],
             'banned_genres': conf['songs']['ban_list'],
             'music_dir': self.format_path(conf['mpd']['music_dir'])
         }
@@ -40,6 +41,7 @@ class Config:
         conf.set("mpd", "music_dir", "~/Music")
         conf.set("mpd", "host", "localhost")
         conf.set("mpd", "port", "6600")
+        conf.set("mpd", "password", "")
         conf.add_section("browser")
         conf.set("browser", "browser", "google-chrome")
         conf.add_section("songs")

--- a/bandcamp_tagplayer/mpd_queue.py
+++ b/bandcamp_tagplayer/mpd_queue.py
@@ -17,6 +17,8 @@ class MPDConn:
     def __enter__(self):
         self.client = MPDClient()
         self.client.connect(c['mpd_host'], c['mpd_port'])
+        if c['mpd_password']:
+            self.client.password(c['mpd_password'])
         # 0 is random off, 1 is on
         # self.client.random(0)
         return self.client


### PR DESCRIPTION
Allow bandcamp-tagplayer to work if the MPD server requires a password to access the necessary functions (read, add, control, etc.). The MPD password must be stored in plaintext in the config file (I figure anyone who isn't willing to store the password in plaintext doesn't have to use it).

If starting from scratch, it will include an empty password field in the [mpd] section of the generated config file, which is then ignored by the code. However, in its current state, this change requires the user to manually update their pre-existing config file to include the password field. I'm not sure if it would be better to add some logic to update existing config files, or whether there's a simple way to make config file fields optional?