### PR TITLE
Fix compatibility with Python 3.11

### DIFF
--- a/bandcamp_tagplayer/tagplayer.py
+++ b/bandcamp_tagplayer/tagplayer.py
@@ -189,6 +189,8 @@ class Tagplayer:
 
     def grab_four(self, items):
         """ Return 4 items from list, or all if less than 4 """
+        if type(items) is not list:
+            items = sorted(items)
         if len(items) > 4:
             return random.sample(items, 4)
         else:


### PR DESCRIPTION
The `random.sample()` function now requires a list, and will not work if given a set; this commit handles this case by passing the set of items through `sorted()`, as suggested by documentation.